### PR TITLE
Expose Shlexer options to consumers of split

### DIFF
--- a/shlex.js
+++ b/shlex.js
@@ -262,10 +262,15 @@ class Shlexer {
  * Splits a given string using shell-like syntax.
  *
  * @param {String} s String to split.
+ * @param {Object} options Options to apply to the Shlexer
  * @returns {String[]}
  */
-exports.split = function (s) {
-  return Array.from(new Shlexer(s))
+exports.split = function (s, options) {
+  let shlex = new Shlexer(s)
+  for (let option in options) {
+    shlex[option] = options[option]
+  }
+  return Array.from(shlex)
 }
 
 /**


### PR DESCRIPTION
It would be useful to expose the internal Shlexer options in the exported package. That way consumers can use options such as `this.debug` to gain access to the debug information that is logged to the console.