### PR TITLE
Drop node 10, add node 14 + 16, bump setup-node v2

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,12 +11,12 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x, 16.x]
 
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
## Changes:

- Drop Node.js 10 from test matrix, as it's no longer LTS or supported by Node themselves
- Add Node 14 (Current LTS) to test matrix
- Add Node 16 (Current version, will become LTS later on) to text matrix
- Bump actions/setup-node to latest stable version `v2`

## Context:

Official Node.js version support scheme: https://nodejs.org/en/about/releases/

Using the `v2` tags means you're running the latest in the `v2` release line for `actions/setup-node`.

Link to release note for the first stable `v2` release: https://github.com/actions/setup-node/releases/tag/v2.1.4 but check the logs for the `beta` versions of `v2` as well, as they explain what the back-end changes are. Things should just keep on working though.

I don't know if your current code will work on Node 14.x and/or Node 16.x, so you'll have to run the test suite on this PR to find out. 😄 